### PR TITLE
Add standard CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,54 @@
+version: 2
+
+common-steps:
+  - &install-deps
+    run:
+      name: Install system-level and Python dependencies
+      command: |
+        apt-get update && apt-get install -y --no-install-recommends make python3 python3-venv python3-setuptools
+        python3 -m venv .venv
+        ./.venv/bin/pip install --require-hashes -r requirements/requirements.txt
+
+jobs:
+  lint:
+    docker:
+      # We use a standard Debian image to mirror a typical developer environment.
+      # This should be updated whenever a new Debian stable version is available.
+      - image: debian:bullseye
+    steps:
+      - checkout
+      - *install-deps
+      - run:
+          name: Run lint
+          command: |
+            source .venv/bin/activate
+            make docs-lint
+
+  linkcheck:
+    docker:
+      - image: debian:bullseye
+    steps:
+      - checkout
+      - *install-deps
+      - run:
+          name: Run link check
+          command: |
+            source .venv/bin/activate
+            make docs-linkcheck
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - lint
+
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 3 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - linkcheck


### PR DESCRIPTION
Same configuration as used in `securedrop-docs` and `securedrop-workstation-docs`.